### PR TITLE
Added dedicated support for hyperdb

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ function HyperdriveSwarm (archive, opts) {
   this.uploading = !(opts.upload === false)
   this.downloading = !(opts.download === false)
   this.live = !(opts.live === false)
-  this.authorize = !(opts.authorize === false)
 
   var isHyperdbInstance = !!(archive.get && archive.put && archive.replicate && archive.authorize)
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var swarmDefaults = require('datland-swarm-defaults')
 var disc = require('discovery-swarm')
 var xtend = require('xtend')
+// var debug = require('debug')('hyperdiscovery')
 
 module.exports = HyperdriveSwarm
 
@@ -13,24 +14,44 @@ function HyperdriveSwarm (archive, opts) {
   this.uploading = !(opts.upload === false)
   this.downloading = !(opts.download === false)
   this.live = !(opts.live === false)
+  this.authorize = !(opts.authorize === false)
+
+  var isHyperdbInstance = !!(archive.get && archive.put && archive.replicate && archive.authorize)
+
+  if (isHyperdbInstance && !archive.local) {
+    throw new Error('hyperdiscovery swarm must be created after the local hyperdb instance is ready!')
+  }
 
   // Discovery Swarm Options
   opts = xtend({
     port: 3282,
-    id: archive.id,
+    id: isHyperdbInstance ? archive.local.id.toString('hex') : archive.id,
     hash: false,
     stream: function (peer) {
-      return archive.replicate({
+      return archive.replicate(xtend({
         live: self.live,
         upload: self.uploading,
         download: self.downloading
-      })
+      }, isHyperdbInstance ? {
+        userData: archive.local.key
+      } : {}))
     }
   }, opts)
 
   this.swarm = disc(swarmDefaults(opts))
   this.swarm.once('error', function () {
     self.swarm.listen(0)
+  })
+
+  // Authorize peer connections if download is enabled...
+  this.downloading && this.swarm.on('connection', function (peer) {
+    if (peer.remoteUserData) {
+      archive.authorize(peer.remoteUserData, function () {
+        // debug(`Peer "${peer.remoteUserData.toString('hex')}" authenticated`);
+      })
+    } else {
+      // debug(`Attempted to authorize peer without key (${peer})`);
+    }
   })
   this.swarm.listen(opts.port)
   this.swarm.join(this.archive.discoveryKey)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var swarmDefaults = require('dat-swarm-defaults')
 var disc = require('discovery-swarm')
 var xtend = require('xtend')
-// var debug = require('debug')('hyperdiscovery')
 
 module.exports = HyperdriveSwarm
 
@@ -43,16 +42,6 @@ function HyperdriveSwarm (archive, opts) {
     self.swarm.listen(0)
   })
 
-  // Authorize peer connections if download is enabled...
-  this.downloading && this.swarm.on('connection', function (peer) {
-    if (peer.remoteUserData) {
-      archive.authorize(peer.remoteUserData, function () {
-        // debug(`Peer "${peer.remoteUserData.toString('hex')}" authenticated`);
-      })
-    } else {
-      // debug(`Attempted to authorize peer without key (${peer})`);
-    }
-  })
   this.swarm.listen(opts.port)
   this.swarm.join(this.archive.discoveryKey)
   return this.swarm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,6 +1230,117 @@
         }
       }
     },
+    "hyperdb": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hyperdb/-/hyperdb-2.0.0.tgz",
+      "integrity": "sha512-yvbMTBR6vj04gW3WRnn5VoPh7BpjvngQMutSRwdFBVZlmkC2gIItKl8lxb+MzTxUR9supiZ0xzJpEqhOPHbPDA==",
+      "dev": true,
+      "requires": {
+        "array-lru": "1.1.1",
+        "bulk-write-stream": "1.1.3",
+        "codecs": "1.2.0",
+        "hypercore": "6.11.0",
+        "hypercore-protocol": "6.4.0",
+        "inherits": "2.0.3",
+        "mutexify": "1.1.0",
+        "once": "1.4.0",
+        "protocol-buffers": "3.2.1",
+        "random-access-file": "1.8.1",
+        "sodium-universal": "1.4.0",
+        "thunky": "1.0.2",
+        "to-buffer": "1.1.0",
+        "unordered-array-remove": "1.0.2",
+        "varint": "5.0.0"
+      },
+      "dependencies": {
+        "hypercore": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.11.0.tgz",
+          "integrity": "sha512-upk8UvbeJZc921Bi+kW3rLJgdrbfVkVBlB8M4QM4X3IFWz15UbCYnSWgRgN3jf7Qr5t9TF3H4rBZPI68U5wEMA==",
+          "dev": true,
+          "requires": {
+            "array-lru": "1.1.1",
+            "atomic-batcher": "1.0.2",
+            "bitfield-rle": "2.1.0",
+            "buffer-equals": "1.0.4",
+            "bulk-write-stream": "1.1.3",
+            "codecs": "1.2.0",
+            "flat-tree": "1.6.0",
+            "from2": "2.3.0",
+            "hypercore-protocol": "6.5.0",
+            "inherits": "2.0.3",
+            "last-one-wins": "1.0.4",
+            "memory-pager": "1.0.3",
+            "merkle-tree-stream": "3.0.3",
+            "process-nextick-args": "1.0.7",
+            "random-access-file": "1.8.1",
+            "sodium-universal": "2.0.0",
+            "sparse-bitfield": "3.0.3",
+            "thunky": "1.0.2",
+            "uint64be": "2.0.1",
+            "unordered-array-remove": "1.0.2",
+            "unordered-set": "2.0.0"
+          },
+          "dependencies": {
+            "hypercore-protocol": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.5.0.tgz",
+              "integrity": "sha512-gBazLXf+MorZxmDZS/+p8W2vU+6OZgIyMLKV01RljrI/zufqjIXfGdYcSBIJvNZ71jff3O8oA9tDAZ9LNANvPQ==",
+              "dev": true,
+              "requires": {
+                "brfs": "1.4.3",
+                "inherits": "2.0.3",
+                "protocol-buffers": "3.2.1",
+                "readable-stream": "2.3.3",
+                "sodium-universal": "2.0.0",
+                "sorted-indexof": "1.0.0",
+                "varint": "5.0.0"
+              }
+            },
+            "sodium-universal": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-2.0.0.tgz",
+              "integrity": "sha512-csdVyakzHJRyCevY4aZC2Eacda8paf+4nmRGF2N7KxCLKY2Ajn72JsExaQlJQ2BiXJncp44p3T+b80cU+2TTsg==",
+              "dev": true,
+              "requires": {
+                "sodium-javascript": "0.5.1",
+                "sodium-native": "2.1.3"
+              }
+            }
+          }
+        },
+        "sodium-native": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.1.3.tgz",
+          "integrity": "sha512-BLZAiHgr1YPD+D50QpbaPGTNzEu5ozJjMgZhpjMJEijherL3u4vNAhgpRJX7Uuypfo9MCdbcB0fguXFijngWzg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ini": "1.3.5",
+            "nan": "2.6.2",
+            "node-gyp-build": "3.2.0"
+          }
+        },
+        "thunky": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
+          "integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E=",
+          "dev": true
+        },
+        "unordered-set": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.0.tgz",
+          "integrity": "sha1-mFon6XW6oguCY66np5HpMAlBqew=",
+          "dev": true
+        },
+        "varint": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+          "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=",
+          "dev": true
+        }
+      }
+    },
     "hyperdrive": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-8.3.2.tgz",
@@ -1283,6 +1394,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true,
+      "optional": true
     },
     "inquirer": {
       "version": "0.12.0",
@@ -2327,14 +2445,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2355,6 +2465,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.7.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "dependency-check": "^2.8.0",
     "hypercore": "^5.11.0",
+    "hyperdb": "^2.0.0",
     "hyperdrive": "^8.2.1",
     "random-access-memory": "^2.4.0",
     "standard": "^7.1.2",

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ db.on('ready', function() {
 })
 ```
 
-A hyperdb database must be ready before attempting to connect to the swarm. By default the swarm will `db.authorize()` all connecting peers. Auto authorization can be disabled using the `authorize` option (details below).
+A hyperdb database must be ready before attempting to connect to the swarm. When `download` is enabled the swarm will automatically `db.authorize()` all connecting peers.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 [![build status](https://travis-ci.org/karissa/hyperdiscovery.svg?branch=master)](http://travis-ci.org/karissa/hyperdiscovery)
 
-Join the p2p swarm for [hypercore][core] and [hyperdrive][drive] feeds. Uses
+Join the p2p swarm for [hypercore][core], [hyperdrive][drive], and [hyperdb][db] feeds. Uses
 [discovery-swarm][swarm] under the hood.
 
 ```
@@ -39,6 +39,20 @@ var swarm = require('hyperdiscovery')
 var feed = hypercore('/feed')
 var sw = swarm(feed)
 ```
+
+The module can also create and join a swarm for a hyperdb feed:
+
+```js
+var hyperdb = require('hyperdb')
+var swarm = require('hyperdiscovery')
+
+var db = hyperdb('/feed', 'ARCHIVE_KEY')
+db.on('ready', function() {
+  var sw = swarm(db)
+})
+```
+
+A hyperdb database must be ready before attempting to connect to the swarm. By default the swarm will `db.authorize()` all connecting peers. Auto authorization can be disabled using the `authorize` option (details below).
 
 ## API
 
@@ -79,4 +93,5 @@ ISC
 
 [core]: https://github.com/mafintosh/hypercore
 [drive]: https://github.com/mafintosh/hyperdrive
+[db]: https://github.com/mafintosh/hyperdb
 [swarm]: https://github.com/mafintosh/discovery-swarm

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ Defaults from datland-swarm-defaults can also be overwritten:
 ## See Also
 - [mafintosh/hypercore][core]
 - [mafintosh/hyperdrive][drive]
+- [mafintosh/hyperdb][db]
 - [mafintosh/discovery-swarm][swarm]
 
 ## License

--- a/test.js
+++ b/test.js
@@ -1,9 +1,10 @@
 var tape = require('tape')
 var hypercore = require('hypercore')
+var hyperdb = require('hyperdb')
 var ram = require('random-access-memory')
 var swarm = require('.')
 
-function getSwarms (opts, cb) {
+function getHypercoreSwarms (opts, cb) {
   var feed1 = hypercore(ram)
   feed1.once('ready', function () {
     var feed2 = hypercore(ram, feed1.key)
@@ -16,9 +17,23 @@ function getSwarms (opts, cb) {
   })
 }
 
+function getDbSwarms (opts, cb) {
+  var left = hyperdb(ram, {valueEncoding: 'utf-8'})
+  left.once('ready', function () {
+    var right = hyperdb(ram, left.key, {valueEncoding: 'utf-8'})
+    right.once('ready', function () {
+      var leftSwarm = swarm(left, opts)
+      var rightSwarm = swarm(right, opts)
+      var dbs = [left, right]
+      var swarms = [leftSwarm, rightSwarm]
+      cb(dbs, swarms)
+    })
+  })
+}
+
 tape('connect and close', function (t) {
   t.plan(6)
-  getSwarms({}, function (swarms) {
+  getHypercoreSwarms({}, function (swarms) {
     var write = swarms[0]
     var read = swarms[1]
     var missing = 2
@@ -49,7 +64,7 @@ tape('connect and close', function (t) {
 
 tape('connect without utp', function (t) {
   t.plan(6)
-  getSwarms({utp: false}, function (swarms) {
+  getHypercoreSwarms({utp: false}, function (swarms) {
     var write = swarms[0]
     var read = swarms[1]
     var missing = 2
@@ -77,3 +92,60 @@ tape('connect without utp', function (t) {
     }
   })
 })
+
+tape('hyperdb two-way sync', function (t) {
+  t.plan(6)
+  getDbSwarms({}, function (dbs, swarms) {
+    var left = dbs[0]
+    var right = dbs[1]
+    var leftSwarm = swarms[0]
+    var rightSwarm = swarms[1]
+    var delay = 50
+    var missing = 2
+
+    testSettingValue(left, right, '/left', 'left to right', done)
+    testSettingValue(right, left, '/right', 'right to left', done)
+
+    function testSettingValue (src, dest, key, expectedValue, cb) {
+      src.put(key, expectedValue, function (err) {
+        if (err) throw err
+        setTimeout(function () {
+          getDbValues(src, dest, key, function (srcVal, destVal) {
+            t.is(srcVal, expectedValue)
+            t.is(destVal, expectedValue)
+            cb()
+          })
+        }, delay)
+      })
+    }
+
+    function done () {
+      if (--missing) return
+      leftSwarm.close(function () {
+        t.ok(1, 'left closed')
+        rightSwarm.close(function () {
+          t.ok(1, 'right closed')
+        })
+      })
+    }
+  })
+})
+
+function getDbValues (src, dest, key, cb) {
+  var srcValue, destValue
+  src.get(key, function (err, entry) {
+    if (err) throw err
+    srcValue = entry[0].value
+    done()
+  })
+  dest.get(key, function (err, entry) {
+    if (err) throw err
+    destValue = entry[0].value
+    done()
+  })
+
+  function done () {
+    if (!srcValue || !destValue) return
+    cb(srcValue, destValue)
+  }
+}


### PR DESCRIPTION
As per the discussion on #11 here is dedicated support for hyperdb. There are 3 major requirements, the first is passing the correct `id` to hyperdiscovery, the second is overriding the stream to include the local id in the `userData` (exposed by hypercore-protocol), and the third is authenticating new connections based on that `remoteUserData`. This achieves all three only when it is a hyperdb instance (or when it looks like one, any recommendations for testing if hyperdb would be appreciated) in the least intrusive way.

I left some `debug` log calls in there commented out, just to indicate what I've done locally, but I can remove those if this PR is something that could be merged.

The tests do use a timeout to delay because I couldn't find a good event to bind to for indicating when two databases are in sync. Arbitrary delays are not ideal but it seems to work fine.

@pvh wanted to see this patch, so if it is too divergent then no worries!