### PR TITLE
fix: feeds should not be removed when peers leave otherwise others can

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,12 +177,6 @@ class Hyperdiscovery extends EventEmitter {
 
       function onend () {
         feed.replicationStreams = feed.replicationStreams.filter(s => (s !== stream))
-
-        // If the Replicator is the only object with a reference to this core, close it after replication's finished.
-        if (!feed.replicationStreams.length) {
-          self._replicatingFeeds.delete(dkeyStr)
-          feed.close()
-        }
       }
       stream.once('error', onend)
       stream.once('end', onend)


### PR DESCRIPTION
Open question, when do feeds get removed? Explicitly via a remove method? 

To reproduce the bug:

```
git clone git@github.com:karissa/hyperhealth.git
cd hyperhealth
git checkout update
node share-core.js
<key>
```

In another terminal, run `node cli <key>`. Peers connect just fine. Now, try to rejoin by hitting Ctrl+C and running `node cli <key>` again. They won't connect.