### PR TITLE
BREAKING: change join/close api surface. add closeFeed & deprecate to…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Join the p2p swarm for the given feed. The return object, `discovery`, is an eve
 
 Add an archive/feed to the discovery swarm.
 
-### `discovery.totalConnections`
+### `discovery.connections`
 
 Get the list of total active connections, across all archives and feeds.
 
@@ -77,13 +77,17 @@ Get the list of total active connections, across all archives and feeds.
 
 Leave discovery for a specific discovery key.
 
-### `discovery.rejoin(discoveryKey)`
+### `discovery.join(discoveryKey)`
 
-Rejoin discovery for a discovery key (*must be added first using `discovery.add`).
+Join discovery for a discovery key (*must be added first using `discovery.add`).
+
+### `discovery.closeFeed(discoveryKey)`
+
+Close replication streams for the given discovery key. 
 
 ### `discovery.close()`
 
-Exit the swarm, close all replication streams.
+Exit the swarm, close replication streams. 
 
 ##### Options
 
@@ -103,7 +107,6 @@ Defaults from datland-swarm-defaults can also be overwritten:
 ## See Also
 - [mafintosh/hypercore][core]
 - [mafintosh/hyperdrive][drive]
-- [mafintosh/hyperdb][db]
 - [mafintosh/discovery-swarm][swarm]
 
 ## License


### PR DESCRIPTION
* change join/close api surface
* add closeFeed 
* deprecate `totalConnections` and `rejoin`
fixes #23 and #27 